### PR TITLE
Bug: Fix typos in `gdcl.rb` and  change the word `Goldendict` to `GoldenDict`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 gdcl is a command-line interface for searching [GoldenDict](https://github.com/goldendict/goldendict) dictionaries. A request for a command-line version is currently [the third most commented issue](https://github.com/goldendict/goldendict/issues/37) on the GoldenDict issue tracker. This script is a very rudimentary workaround to allow searching through groups of dictionaries until an official command-line interface is available.
 
-As an example of a similar interface, [Stardict](http://code.google.com/p/stardict-3/) has [sdcv](http://sdcv.sourceforge.net/) (Stardict Console Version), but it can only handle dictionaries in the Stardict format. For users of GoldenDict who have dictionaries in other formats (e.g. DSL or BGL), converting and maintaining two parallel sets of dictionaries is not a practical solution.
+As an example of a similar interface, [StarDict](http://code.google.com/p/stardict-3/) has [sdcv](http://sdcv.sourceforge.net/) (StarDict Console Version), but it can only handle dictionaries in the StarDict format. For users of GoldenDict who have dictionaries in other formats (e.g. DSL or BGL), converting and maintaining two parallel sets of dictionaries is not a practical solution.
 
 This script answers a practical need: namely the ability to search through groups of dsl format dictionaries from the command-line over ssh. The script can be used search dictionaries interactively, but also has an interactive mode which allows results from GoldenDict dictionaries to piped to standard output or used as part of a toolchain.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# gdcl - Goldendict command-line interface written in Ruby
+# gdcl - GoldenDict command-line interface written in Ruby
 
-gdcl is a command-line interface for searching [Goldendict](https://github.com/goldendict/goldendict) dictionaries. A request for a command-line version is currently [the third most commented issue](https://github.com/goldendict/goldendict/issues/37) on the Goldendict issue tracker. This script is a very rudimentary workaround to allow searching through groups of dictionaries until an official command-line interface is available.
+gdcl is a command-line interface for searching [GoldenDict](https://github.com/goldendict/goldendict) dictionaries. A request for a command-line version is currently [the third most commented issue](https://github.com/goldendict/goldendict/issues/37) on the GoldenDict issue tracker. This script is a very rudimentary workaround to allow searching through groups of dictionaries until an official command-line interface is available.
 
-As an example of a similar interface, [Stardict](http://code.google.com/p/stardict-3/) has [sdcv](http://sdcv.sourceforge.net/) (Stardict Console Version), but it can only handle dictionaries in the Stardict format. For users of Goldendict who have dictionaries in other formats (e.g. DSL or BGL), converting and maintaining two parallel sets of dictionaries is not a practical solution.
+As an example of a similar interface, [Stardict](http://code.google.com/p/stardict-3/) has [sdcv](http://sdcv.sourceforge.net/) (Stardict Console Version), but it can only handle dictionaries in the Stardict format. For users of GoldenDict who have dictionaries in other formats (e.g. DSL or BGL), converting and maintaining two parallel sets of dictionaries is not a practical solution.
 
-This script answers a practical need: namely the ability to search through groups of dsl format dictionaries from the command-line over ssh. The script can be used search dictionaries interactively, but also has an interactive mode which allows results from Goldendict dictionaries to piped to standard output or used as part of a toolchain.
+This script answers a practical need: namely the ability to search through groups of dsl format dictionaries from the command-line over ssh. The script can be used search dictionaries interactively, but also has an interactive mode which allows results from GoldenDict dictionaries to piped to standard output or used as part of a toolchain.
 
-Currently, gdcl does not require an installation of Goldendict, as it simply searches through predetermined groups of dictionaries in the Goldendict folder (which can be configured) and could conceivably be used to search through any collection of dsl format dictionaries. However, the eventual goal of the project is to read preferences from Goldendict's config file, support the full range of formats that Goldendict can use and, ideally, to use Goldendict's pre-made index files for faster searching.
+Currently, gdcl does not require an installation of GoldenDict, as it simply searches through predetermined groups of dictionaries in the GoldenDict folder (which can be configured) and could conceivably be used to search through any collection of dsl format dictionaries. However, the eventual goal of the project is to read preferences from GoldenDict's config file, support the full range of formats that GoldenDict can use and, ideally, to use GoldenDict's pre-made index files for faster searching.
 
 
 ## Usage
@@ -26,7 +26,7 @@ See below for configuration and usage details.
 #### gdcg.rb
 The easiest way to set up dictionaries for use with gdcl is to use the gdcg.rb script, which can automatically configure groups of dictionaries for quick searching. By default this looks in the `.goldendict` directory located in the user's home folder, but it can be configured to use any folder containing zipped dsl dictionaries (i.e.: files with the extension .dsl.dz).
 
-If you use gdcg.rb, it assumes that your dictionaries are located in a folder `dic` in your Goldendict directory, separated into subdirectories representing groups of dictionaries that you would like to search. For example, English dictionaries might be in a subfolder called `en`, French dictionaries in `fr`, and Chemistry dictionaries in a folder `chem`. Using gdcl allows you to search through these groups individually, similar to the way Goldendict does.
+If you use gdcg.rb, it assumes that your dictionaries are located in a folder `dic` in your GoldenDict directory, separated into subdirectories representing groups of dictionaries that you would like to search. For example, English dictionaries might be in a subfolder called `en`, French dictionaries in `fr`, and Chemistry dictionaries in a folder `chem`. Using gdcl allows you to search through these groups individually, similar to the way GoldenDict does.
 
 Alternatively, you can just point the gdcl.rb script at any folder containing _unzipped_ dsl files and avoid the need to use gdcg.rb altogether.
 
@@ -35,7 +35,7 @@ The script for actually searching through the dictionary is called gdcl.rb.
 
 There are a number of configuration options at the beginning of the script which should be self-explanatory. These are listed below:
 
-* `group`: _Group name_ (either a subfolder of your Goldendict home directory setup by gdcg.rb, or any arbitrary folder located [by default] in the script's `tmp` directory
+* `group`: _Group name_ (either a subfolder of your GoldenDict home directory setup by gdcg.rb, or any arbitrary folder located [by default] in the script's `tmp` directory
 * `kword`: _Keyword to search for_ (use this to specify a keyword in the script; if not specified here, gdcl will search for a term provided either interactively or on the command line)
 * `interactive_search`: _Interactive search_ (Set to false for non-interactive search, e.g. to pipe or redirect the search results; defaults to false if a group and keyword are specified as command-line parameters)
 * `header_footer`: _Header and footer information_ (Set to false to turn off header and footer information, i.e.: dictionary name and number of hits for search term)
@@ -72,8 +72,8 @@ To pipe dictionary search results to a file:
 ## To do
 
 Features that need to be implemented:
-* Read search and dictionary preferences from Goldendict config file
-* Search using Goldendict's existing index files
+* Read search and dictionary preferences from GoldenDict config file
+* Search using GoldenDict's existing index files
 * Dictzip support (i.e. search dictionaries in place rather than needing to unzip them to tmp folder)
 * bgl, dict and other formats support
 * Online dictionaries support (Wikipedia, Wiktionary etc)

--- a/gdcg.rb
+++ b/gdcg.rb
@@ -4,7 +4,7 @@
 require 'fileutils'
 
 # Run this script to set up your dictionaries in groups for quicker searching.
-# By default it looks for groups of dictionaries arranged in subfolders under your Goldendict folder.
+# By default it looks for groups of dictionaries arranged in subfolders under your GoldenDict folder.
 # NOTE: Using this script is optional: it merely simplifies the process of creating dictionary groups.
 # You can configure gdcl to use any arbitrary group of dictionaries by changing the default directory in the configuration options.
 # To search, use gdcl.rb rather than this script.

--- a/gdcl.rb
+++ b/gdcl.rb
@@ -12,7 +12,7 @@
 
 # ==Configuration options==
 
-# Group name (at the moment this should be the name of a subfolder in your Goldendict dictionary directory)
+# Group name (at the moment this should be the name of a subfolder in your GoldenDict dictionary directory)
 group = ""
 
 # Keyword to search for

--- a/gdcl.rb
+++ b/gdcl.rb
@@ -2,10 +2,10 @@
 # encoding: utf-8
 
 # invoke with:
-# ruby lookup.rb
+# ruby gdcl.rb
 # (for interactive search)
 # OR
-# ruby lookup.rb [group] [keyword]
+# ruby gdcl.rb [group] [keyword]
 # (for non-interactive search)
 
 ########################
@@ -26,7 +26,7 @@ interactive_search = true
 header_footer = true
 
 # Temporary working directory where gdcl will store files
-# Note: if you used group.rb to set up your dsl files, you should probably use the default here
+# Note: if you used gdcg.rb to set up your dsl files, you should probably use the default here
 temp_dir = "#{Dir.home}/.goldendict/gdcl/tmp"
 
 # Search pattern (specify a pattern to search for, default is headwords starting with keyword; include regex between // slashes)


### PR DESCRIPTION
Hello, @dohliam !

Appreciate your great work! :rose: However, I think that it is a long way to get stable. I have two proposals for this program:
## 1 Fix typos in `gdcl.rb`

Since the executables have been renamed, some comments should be updated
too. The word `lookup.rb` is changed to `gdcl.rb` accordingly and so is `group.rb`.

This fixes typos which are imported in https://github.com/dohliam/gdcl/commit/298ec38b27813cfb43ff9de457d89aa95edd0f3f
## 2 Change the word `Goldendict` to `GoldenDict` and `Stardict` to `StarDict`

Some terminologies and names have special case styles, such as `PhD`, `gVim` and `openSUSE`. `GoldenDict` and `StarDict` use the [CamelCase](https://en.wikipedia.org/wiki/CamelCase) style. So it's better to respect the official name of `GoldenDict` as https://github.com/goldendict/goldendict/blob/master/README.md and http://goldendict.org/ show; the official name of `StarDict` as http://stardict-4.sourceforge.net/ and http://www.stardict.org/ show.

Do you agree with me? :sweat_smile: Hope for your reply!

Yours sincerely! :bow: 
